### PR TITLE
Add support for secp521r1 (NIST P521)

### DIFF
--- a/create_linux_tvs.sh
+++ b/create_linux_tvs.sh
@@ -2,7 +2,7 @@
 
 # Script to generate Linux test vectors
 
-CURVE="prime256v1"
+CURVE="secp521r1"
 
 for hash in sha1 sha224 sha256 sha384 sha512; do
 	openssl req \
@@ -23,15 +23,16 @@ for hash in sha1 sha224 sha256 sha384 sha512; do
 	#echo $line
 	skip=$(echo $line | cut -d":" -f1)
 	#echo $skip
+	hl=$(echo $line | sed -n 's/.*hl=\s*\([^ ]*\).*/\1/p')-2
 	length=$(echo $line | sed -n 's/.*l=\s*\([^ ]*\).*/\1/p')
 	#echo "l=$length"
 	echo -e "\t.key ="
-	dd bs=1 count=$((length-1)) skip=$((skip+3)) if=cert.der 2>/dev/null |
+	dd bs=1 count=$((length-1)) skip=$((skip+3+hl)) if=cert.der 2>/dev/null |
 		od -tx1 |
 		sed -n "s/^[0-9]\{7\} \(.*\)$/\t\" \1/p" |
 		sed -n "s/ \([0-9a-f]\)/\\\x\1/gp"
 	echo ","
-	echo -e "\t.key_len = ,"
+	echo -e "\t.key_len = $((length-1)),"
 	#openssl asn1parse -in cert.der -inform der
 	line=$(openssl asn1parse -in cert.der -inform der 2>&1|
 		grep id-ecPublicKey -B1 |

--- a/test-ecc-kernel-keys.sh
+++ b/test-ecc-kernel-keys.sh
@@ -80,6 +80,24 @@ main() {
       tmpcurves="${tmpcurves} ${curve}"
     fi
   done
+
+  curves=${tmpcurves}
+  tmpcurves=""
+  for curve in ${curves}; do
+    case "${curve}" in
+    prime192v1) tmp="ecdsa-nist-p192";;
+    prime256v1) tmp="ecdsa-nist-p256";;
+    secp384r1) tmp="ecdsa-nist-p384";;
+    secp521r1) tmp="ecdsa-nist-p521";;
+    *) echo "Internal error: Unknown curve $curve"; exit 1;;
+    esac
+    if grep -q "${tmp}" /proc/crypto; then
+      tmpcurves="${tmpcurves} ${curve}"
+    else
+      echo "${curve} not supported by kernel driver"
+    fi
+  done
+
   curves=${tmpcurves}
   if [ -z "${curves}" ]; then
     echo "No curves to test with. Try one of the following:"

--- a/test-ecc-kernel-keys.sh
+++ b/test-ecc-kernel-keys.sh
@@ -71,7 +71,7 @@ main() {
 
   keyctl newring test @u
 
-  curves=${CURVES:-prime256v1 prime192v1 secp384r1}
+  curves=${CURVES:-prime256v1 prime192v1 secp384r1 secp521r1}
   for curve in ${curves}; do
     tmp=$(openssl ecparam -list_curves | grep -E "\s*${curve}\s*:")
     if [ -n "${tmp}" ]; then
@@ -88,7 +88,7 @@ main() {
 
   while :; do
     for curve in ${curves}; do
-      for hash in sha1 sha224 sha256 sha384 sha512; do
+      for hash in sha224 sha256 sha384 sha512; do
         certfile="cert.der"
         openssl req \
                 -x509 \

--- a/test-ecc-kernel-keys.sh
+++ b/test-ecc-kernel-keys.sh
@@ -18,7 +18,7 @@ inject_fault_cert_key() {
 
   cp -f "${certfilein}" "${certfileout}"
 
-  line=$(openssl asn1parse -inform der -in ${certfilein} |
+  line=$(openssl asn1parse -inform der -in "${certfilein}" |
         grep "BIT STRING" |
         head -n1)
   offset=$(echo "${line}" | cut -d":" -f1)
@@ -46,7 +46,7 @@ inject_fault_cert_signature() {
 
   cp -f "${certfilein}" "${certfileout}"
 
-  line=$(openssl asn1parse -inform der -in ${certfilein} |
+  line=$(openssl asn1parse -inform der -in "${certfilein}" |
         grep "BIT STRING" |
         tail -n1)
   offset=$(echo "${line}" | cut -d":" -f1)
@@ -72,7 +72,7 @@ main() {
   keyctl newring test @u
 
   curves=${CURVES:-prime256v1 prime192v1 secp384r1}
-  for curve in $(echo ${curves}); do
+  for curve in ${curves}; do
     tmp=$(openssl ecparam -list_curves | grep -E "\s*${curve}\s*:")
     if [ -n "${tmp}" ]; then
       tmpcurves="${tmpcurves} ${curve}"
@@ -87,20 +87,20 @@ main() {
   echo "Testing with curves: ${curves}"
 
   while :; do
-    for curve in $(echo ${curves}); do
+    for curve in ${curves}; do
       for hash in sha1 sha224 sha256 sha384 sha512; do
         certfile="cert.der"
         openssl req \
-        	-x509 \
-        	-${hash} \
-        	-newkey ec \
-        	-pkeyopt ec_paramgen_curve:${curve} \
-        	-keyout key.pem \
-        	-days 365 \
-        	-subj '/CN=test' \
-        	-nodes \
-        	-outform der \
-        	-out ${certfile} 2>/dev/null
+                -x509 \
+                -${hash} \
+                -newkey ec \
+                -pkeyopt "ec_paramgen_curve:${curve}" \
+                -keyout key.pem \
+                -days 365 \
+                -subj '/CN=test' \
+                -nodes \
+                -outform der \
+                -out "${certfile}" 2>/dev/null
 
         exp=0
         # Every once in a while we inject a fault into the
@@ -129,8 +129,8 @@ main() {
           exit 1
         else
           case "$rc" in
-          0) printf "Good: curve: %10s hash: %-7s keyid: %-10s\n" $curve $hash $id;;
-          *) printf "Good: curve: %10s hash: %-7s keyid: %-10s -- bad certificate was rejected\n" $curve $hash $id;;
+          0) printf "Good: curve: %10s hash: %-7s keyid: %-10s\n" "$curve" $hash "$id";;
+          *) printf "Good: curve: %10s hash: %-7s keyid: %-10s -- bad certificate was rejected\n" "$curve" $hash "$id";;
           esac
         fi
       done


### PR DESCRIPTION
Correct the test vector generation for secp521r1 support and add tests
for signature verification, including expected failure to verify bad
signature.